### PR TITLE
Throw error if an error occurs while downloading a file

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,9 @@ function getFile(urlObj, options) {
   // Avoids "Unhandled stream error in pipe" messages.
   // gulp will still fail the containing task if there is
   // an error downloading
-  file.contents.on('error', function() {});
+  file.contents.on('error', function(e) {
+    throw e;
+  });
 
   // Request errors passed to file contents
   function emitError(e) {

--- a/index.js
+++ b/index.js
@@ -25,13 +25,6 @@ function getFile(urlObj, options) {
     contents: stream.PassThrough()
   });
 
-  // Avoids "Unhandled stream error in pipe" messages.
-  // gulp will still fail the containing task if there is
-  // an error downloading
-  file.contents.on('error', function(e) {
-    throw e;
-  });
-
   // Request errors passed to file contents
   function emitError(e) {
     errored = true;

--- a/tests/test.js
+++ b/tests/test.js
@@ -28,7 +28,9 @@ describe('gulp-download-stream', function() {
     });
 
     mockRequest = sinon.spy(function(options) {
-      source = stream.Readable();
+      source = stream.Readable({
+        read: function() {}
+      });
       return source;
     });
 


### PR DESCRIPTION
This makes gulp halt execution instead of silently failing the task without finishing

Feel free to close this PR if there's a better way to catch errors from the download to make a gulp task fail.
Right now, there doesn't seem to be a way to fail the gulp task `download()` is called from.

In my case, this task silently fails (without reporting failure), causing everything in the dependency tree below it to not run while gulp exits with success.
On CI, this means the build is green while all tasks that depend on the download were never run.